### PR TITLE
Cybersource (v25.2.0) compatibility fixes for Hybris JDK21.

### DIFF
--- a/hybris/bin/b2b/isvpayment/external-dependencies.xml
+++ b/hybris/bin/b2b/isvpayment/external-dependencies.xml
@@ -6,6 +6,9 @@
     <version>2011.0</version>
 
     <packaging>jar</packaging>
+    <properties>
+        <maven.compiler.release>21</maven.compiler.release>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -71,7 +74,7 @@
         <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
-            <version>4.2.3</version>
+            <version>5.1.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.inject.extensions</groupId>
@@ -171,6 +174,21 @@
             <version>1.4.0</version>
         </dependency>
         <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.xml.ws</groupId>
+            <artifactId>jakarta.xml.ws-api</artifactId>
+            <version>3.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.xml.soap</groupId>
+            <artifactId>jakarta.xml.soap-api</artifactId>
+            <version>2.0.1</version>
+        </dependency>
+        <dependency>
             <groupId>com.sun.xml.ws</groupId>
             <artifactId>rt</artifactId>
             <version>2.3.2</version>
@@ -210,15 +228,35 @@
             <artifactId>encoder</artifactId>
             <version>1.2.3</version>
         </dependency>
-		 <dependency>
-			<groupId>org.apache.santuario</groupId>
-			<artifactId>xmlsec</artifactId>
-			<version>4.0.3</version>
-		</dependency> 
+         <dependency>
+          <groupId>org.apache.santuario</groupId>
+          <artifactId>xmlsec</artifactId>
+          <version>4.0.3</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
             <version>1.12.0</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-configuration</groupId>
+            <artifactId>commons-configuration</artifactId>
+            <version>1.8</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.6</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+            <version>3.2.2</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <version>1</version>
         </dependency>
     </dependencies>
 </project>

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/commerceservices/order/DefaultPaymentCartService.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/commerceservices/order/DefaultPaymentCartService.java
@@ -1,6 +1,6 @@
 package isv.sap.payment.commerceservices.order;
 
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 import de.hybris.platform.core.model.order.CartModel;
 import de.hybris.platform.servicelayer.model.ModelService;

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/configuration/resolver/AbstractPaymentConfigurationResolver.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/configuration/resolver/AbstractPaymentConfigurationResolver.java
@@ -7,10 +7,9 @@ import de.hybris.platform.servicelayer.exceptions.AmbiguousIdentifierException;
 import de.hybris.platform.servicelayer.exceptions.ModelNotFoundException;
 import de.hybris.platform.servicelayer.search.FlexibleSearchQuery;
 import de.hybris.platform.servicelayer.search.FlexibleSearchService;
-import org.springframework.beans.factory.annotation.Required;
 
 import static isv.sap.payment.utils.Assert.isTrue;
-import static org.apache.commons.collections.CollectionUtils.isNotEmpty;
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 
 /**
  * Base implementation for configuration lookup
@@ -40,7 +39,6 @@ public abstract class AbstractPaymentConfigurationResolver<T> implements Payment
         return flexibleSearchService;
     }
 
-    @Required
     public void setFlexibleSearchService(final FlexibleSearchService flexibleSearchService)
     {
         this.flexibleSearchService = flexibleSearchService;

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/configuration/resolver/IsvConfigurationResolver.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/configuration/resolver/IsvConfigurationResolver.java
@@ -1,6 +1,8 @@
 package isv.sap.payment.configuration.resolver;
 
 import de.hybris.platform.core.Registry;
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.MapConfiguration;
 
@@ -11,6 +13,8 @@ public class IsvConfigurationResolver implements ConfigurationResolver
     @Override
     public Configuration resolve()
     {
-        return new MapConfiguration(Registry.getMasterTenant().getConfig().getAllParameters());
+        //return new MapConfiguration(Registry.getMasterTenant().getConfig().getAllParameters());
+        final Map<String, Object> params = new HashMap<>(Registry.getMasterTenant().getConfig().getAllParameters());
+        return new MapConfiguration(params);
     }
 }

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/configuration/service/DefaultPaymentConfigurationService.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/configuration/service/DefaultPaymentConfigurationService.java
@@ -2,7 +2,6 @@ package isv.sap.payment.configuration.service;
 
 import java.util.Map;
 
-import org.springframework.beans.factory.annotation.Required;
 import org.springframework.util.Assert;
 
 import isv.sap.payment.configuration.resolver.PaymentConfigurationResolver;
@@ -30,7 +29,6 @@ public class DefaultPaymentConfigurationService implements PaymentConfigurationS
         return (T) resolver.resolve(params);
     }
 
-    @Required
     public void setResolverMap(final Map<IsvConfigurationType, PaymentConfigurationResolver> resolverMap)
     {
         this.resolverMap = resolverMap;

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/cronjob/AbstractConversionReportPollingJob.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/cronjob/AbstractConversionReportPollingJob.java
@@ -2,7 +2,7 @@ package isv.sap.payment.cronjob;
 
 import java.util.Date;
 import java.util.List;
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 import de.hybris.platform.cronjob.enums.CronJobResult;
 import de.hybris.platform.cronjob.enums.CronJobStatus;

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/cronjob/DailyConversionReportPollingJob.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/cronjob/DailyConversionReportPollingJob.java
@@ -1,7 +1,7 @@
 package isv.sap.payment.cronjob;
 
 import java.util.Date;
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 import org.joda.time.Interval;
 

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/cronjob/OnDemandConversionReportPollingJob.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/cronjob/OnDemandConversionReportPollingJob.java
@@ -1,7 +1,7 @@
 package isv.sap.payment.cronjob;
 
 import java.util.Date;
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 import de.hybris.platform.servicelayer.time.TimeService;
 import org.joda.time.Interval;

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/cronjob/UpdateAlternativePaymentOptionsJob.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/cronjob/UpdateAlternativePaymentOptionsJob.java
@@ -2,7 +2,7 @@ package isv.sap.payment.cronjob;
 
 import java.util.Collection;
 import java.util.List;
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 import de.hybris.platform.servicelayer.cronjob.PerformResult;
 import de.hybris.platform.servicelayer.dto.converter.Converter;

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/cronjob/UpdateAlternativePaymentOrderStatusJob.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/cronjob/UpdateAlternativePaymentOrderStatusJob.java
@@ -1,6 +1,6 @@
 package isv.sap.payment.cronjob;
 
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 import de.hybris.platform.core.enums.OrderStatus;
 import de.hybris.platform.core.model.order.OrderModel;

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/dao/DefaultPaymentOrderDao.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/dao/DefaultPaymentOrderDao.java
@@ -1,12 +1,12 @@
 package isv.sap.payment.dao;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.List;
 
 import de.hybris.platform.core.enums.OrderStatus;
 import de.hybris.platform.core.model.order.OrderModel;
 import de.hybris.platform.order.daos.impl.DefaultOrderDao;
 import de.hybris.platform.servicelayer.exceptions.ModelNotFoundException;
-import jersey.repackaged.com.google.common.collect.ImmutableMap;
 
 public class DefaultPaymentOrderDao extends DefaultOrderDao implements PaymentOrderDao
 {

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/data/PaymentSystemInfo.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/data/PaymentSystemInfo.java
@@ -1,10 +1,10 @@
 package isv.sap.payment.data;
 
-import javax.annotation.PostConstruct;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+import jakarta.annotation.PostConstruct;
 
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.PropertiesConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -44,16 +44,23 @@ public class PaymentSystemInfo
         {
             setClientLibraryVersion();
         }
-        catch (final ConfigurationException e)
+        catch (final IOException e)
         {
             LOG.warn(e.getMessage(), e);
         }
     }
 
-    protected void setClientLibraryVersion() throws ConfigurationException
+    protected void setClientLibraryVersion() throws IOException
     {
-        final Configuration versionInfo = new PropertiesConfiguration(VERSION_INFO_FILE);
-        clientLibraryVersion = versionInfo.getString("build_version");
+        try (InputStream stream = getClass().getClassLoader().getResourceAsStream(VERSION_INFO_FILE))
+        {
+            if (stream != null)
+            {
+                final Properties props = new Properties();
+                props.load(stream);
+                clientLibraryVersion = props.getProperty("build_version");
+            }
+        }
     }
 
     public String getPartnerSolutionID()

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/fraud/DefaultFraudFacade.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/fraud/DefaultFraudFacade.java
@@ -1,7 +1,7 @@
 package isv.sap.payment.fraud;
 
 import java.time.Instant;
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 import de.hybris.platform.core.model.order.CartModel;
 import de.hybris.platform.order.CartService;

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/injector/DefaultGuiceInjectorFactory.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/injector/DefaultGuiceInjectorFactory.java
@@ -6,7 +6,6 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.util.Modules;
-import org.springframework.beans.factory.annotation.Required;
 
 import isv.cjl.module.PaymentModule;
 
@@ -31,7 +30,6 @@ public class DefaultGuiceInjectorFactory
         return parentModule;
     }
 
-    @Required
     public void setModules(final List<Module> modules)
     {
         this.modules = modules;

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/injector/GuiceFactoryBean.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/injector/GuiceFactoryBean.java
@@ -1,14 +1,13 @@
 package isv.sap.payment.injector;
 
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 import com.google.inject.Injector;
 import org.springframework.beans.factory.FactoryBean;
-import org.springframework.beans.factory.annotation.Required;
 
 import static com.google.inject.Key.get;
 import static com.google.inject.name.Names.named;
-import static org.apache.commons.lang.StringUtils.isNotEmpty;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 public class GuiceFactoryBean<T> implements FactoryBean<T>
 {
@@ -46,7 +45,6 @@ public class GuiceFactoryBean<T> implements FactoryBean<T>
         this.singleton = singleton;
     }
 
-    @Required
     public void setBeanClass(final Class<T> beanClass)
     {
         this.beanClass = beanClass;

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/modules/common/ConfigurationModule.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/modules/common/ConfigurationModule.java
@@ -1,6 +1,6 @@
 package isv.sap.payment.modules.common;
 
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 import org.springframework.guice.annotation.EnableGuiceModules;
 

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/modules/common/IsvPaymentHybrisModule.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/modules/common/IsvPaymentHybrisModule.java
@@ -1,7 +1,7 @@
 package isv.sap.payment.modules.common;
 
 import java.util.List;
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 import com.cybersource.flex.sdk.Credentials;
 import com.google.inject.Key;

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/modules/converter/AlternativePaymentRequestConverterHybrisModule.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/modules/converter/AlternativePaymentRequestConverterHybrisModule.java
@@ -1,6 +1,6 @@
 package isv.sap.payment.modules.converter;
 
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 import org.springframework.guice.annotation.EnableGuiceModules;
 

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/modules/converter/ApplePayRequestConverterHybrisModule.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/modules/converter/ApplePayRequestConverterHybrisModule.java
@@ -1,9 +1,9 @@
 package isv.sap.payment.modules.converter;
 
 import java.util.List;
-import javax.annotation.Resource;
-import javax.inject.Named;
-import javax.inject.Singleton;
+import jakarta.annotation.Resource;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Injector;

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/modules/converter/CreditCardRequestConverterHybrisModule.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/modules/converter/CreditCardRequestConverterHybrisModule.java
@@ -1,6 +1,6 @@
 package isv.sap.payment.modules.converter;
 
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 import org.springframework.guice.annotation.EnableGuiceModules;
 

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/modules/converter/FraudRequestConverterHybrisModule.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/modules/converter/FraudRequestConverterHybrisModule.java
@@ -1,6 +1,6 @@
 package isv.sap.payment.modules.converter;
 
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 import org.springframework.guice.annotation.EnableGuiceModules;
 

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/modules/converter/GooglePayRequestConverterHybrisModule.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/modules/converter/GooglePayRequestConverterHybrisModule.java
@@ -1,6 +1,6 @@
 package isv.sap.payment.modules.converter;
 
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 import com.google.inject.AbstractModule;
 import org.springframework.guice.annotation.EnableGuiceModules;

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/modules/converter/KlarnaRequestConverterHybrisModule.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/modules/converter/KlarnaRequestConverterHybrisModule.java
@@ -1,6 +1,6 @@
 package isv.sap.payment.modules.converter;
 
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 import org.springframework.guice.annotation.EnableGuiceModules;
 

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/modules/converter/PayPalRequestConverterHybrisModule.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/modules/converter/PayPalRequestConverterHybrisModule.java
@@ -1,6 +1,6 @@
 package isv.sap.payment.modules.converter;
 
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 import org.springframework.guice.annotation.EnableGuiceModules;
 

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/modules/converter/PayPalSORequestConverterHybrisModule.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/modules/converter/PayPalSORequestConverterHybrisModule.java
@@ -1,6 +1,6 @@
 package isv.sap.payment.modules.converter;
 
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 import org.springframework.guice.annotation.EnableGuiceModules;
 

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/modules/converter/ReportingTransactionRequestConverterHybrisModule.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/modules/converter/ReportingTransactionRequestConverterHybrisModule.java
@@ -1,6 +1,6 @@
 package isv.sap.payment.modules.converter;
 
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 import org.springframework.guice.annotation.EnableGuiceModules;
 

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/modules/converter/VerificationRequestConverterHybrisModule.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/modules/converter/VerificationRequestConverterHybrisModule.java
@@ -1,6 +1,6 @@
 package isv.sap.payment.modules.converter;
 
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 import org.springframework.guice.annotation.EnableGuiceModules;
 

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/modules/converter/VisaCheckoutRequestConverterHybrisModule.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/modules/converter/VisaCheckoutRequestConverterHybrisModule.java
@@ -1,6 +1,6 @@
 package isv.sap.payment.modules.converter;
 
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 import org.springframework.guice.annotation.EnableGuiceModules;
 

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/option/facade/DefaultPaymentOptionFacade.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/option/facade/DefaultPaymentOptionFacade.java
@@ -1,7 +1,7 @@
 package isv.sap.payment.option.facade;
 
 import java.util.List;
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 import de.hybris.platform.servicelayer.dto.converter.Converter;
 

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/option/service/DefaultPaymentOptionService.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/option/service/DefaultPaymentOptionService.java
@@ -1,7 +1,7 @@
 package isv.sap.payment.option.service;
 
 import java.util.List;
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 import de.hybris.platform.servicelayer.model.ModelService;
 import de.hybris.platform.servicelayer.search.FlexibleSearchService;
@@ -10,7 +10,7 @@ import de.hybris.platform.servicelayer.search.SearchResult;
 import isv.sap.payment.cronjob.UpdateAlternativePaymentOptionsJob;
 import isv.sap.payment.model.IsvAlternativePaymentOptionModel;
 
-import static org.apache.commons.collections.ListUtils.EMPTY_LIST;
+import java.util.Collections;
 
 /**
  * Encapsulates the default implementation of {@link PaymentOptionService} interface.
@@ -32,7 +32,7 @@ public class DefaultPaymentOptionService implements PaymentOptionService
     public List<IsvAlternativePaymentOptionModel> getPaymentOptions()
     {
         final SearchResult<IsvAlternativePaymentOptionModel> options = flexibleSearchService.search(OPTIONS_QUERY);
-        return options.getResult() == null ? EMPTY_LIST : options.getResult();
+        return options.getResult() == null ? Collections.emptyList() : options.getResult();
     }
 
     @Override

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/report/listener/conversion/ProcessConversionReportListener.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/report/listener/conversion/ProcessConversionReportListener.java
@@ -2,16 +2,15 @@ package isv.sap.payment.report.listener.conversion;
 
 import java.util.Collection;
 import java.util.List;
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 import de.hybris.platform.core.enums.OrderStatus;
 import de.hybris.platform.core.model.order.AbstractOrderModel;
 import de.hybris.platform.core.model.order.OrderModel;
 import de.hybris.platform.processengine.BusinessProcessService;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Required;
 
 import isv.cjl.payment.model.ConversionReportInfo;
 import isv.sap.payment.dao.PaymentOrderDao;
@@ -79,7 +78,6 @@ public class ProcessConversionReportListener implements ReportListener<Conversio
         businessProcessService.triggerEvent(order.getCode() + "_ReviewDecision");
     }
 
-    @Required
     public void setDecisionStrategies(final List<DecisionChangeStrategy> decisionStrategies)
     {
         this.decisionStrategies = decisionStrategies;

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/report/listener/conversion/decision/AbstractDecisionStrategy.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/report/listener/conversion/decision/AbstractDecisionStrategy.java
@@ -1,7 +1,7 @@
 package isv.sap.payment.report.listener.conversion.decision;
 
 import java.util.Date;
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 import de.hybris.platform.basecommerce.enums.FraudStatus;
 import de.hybris.platform.core.model.order.OrderModel;

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/DefaultPaymentTransactionService.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/DefaultPaymentTransactionService.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 import com.google.common.collect.Lists;
 import de.hybris.platform.core.model.order.AbstractOrderModel;
@@ -15,7 +15,7 @@ import de.hybris.platform.payment.enums.PaymentTransactionType;
 import de.hybris.platform.payment.model.PaymentTransactionEntryModel;
 import de.hybris.platform.payment.model.PaymentTransactionModel;
 import de.hybris.platform.servicelayer.model.ModelService;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import isv.cjl.payment.constants.PaymentConstants;
 import isv.cjl.payment.enums.CardType;

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/IsvHybrisMerchantService.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/IsvHybrisMerchantService.java
@@ -2,7 +2,7 @@ package isv.sap.payment.service;
 
 import java.util.List;
 import java.util.stream.Collectors;
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/alternativepayment/AlternativePaymentOrderStatusContext.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/alternativepayment/AlternativePaymentOrderStatusContext.java
@@ -1,9 +1,7 @@
 package isv.sap.payment.service.alternativepayment;
 
 import java.util.Map;
-import javax.annotation.Resource;
-
-import org.springframework.beans.factory.annotation.Required;
+import jakarta.annotation.Resource;
 
 import isv.cjl.payment.enums.CheckStatusDecision;
 import isv.sap.payment.enums.AlternativePaymentMethod;
@@ -40,7 +38,6 @@ public class AlternativePaymentOrderStatusContext
         return pendingOrderHandlersMap.getOrDefault(alternativePaymentMethod, defaultPendingOrderHandler);
     }
 
-    @Required
     public void setPendingOrderHandlersMap(
             final Map<AlternativePaymentMethod, AlternativePaymentOrderStatusHandler> pendingOrderHandlersMap)
     {

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/alternativepayment/DefaultAlternativePaymentOrderStatusService.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/alternativepayment/DefaultAlternativePaymentOrderStatusService.java
@@ -4,14 +4,14 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 import com.google.common.collect.Lists;
 import de.hybris.platform.core.enums.OrderStatus;
 import de.hybris.platform.core.model.order.AbstractOrderModel;
 import de.hybris.platform.payment.model.PaymentTransactionEntryModel;
 import de.hybris.platform.servicelayer.model.ModelService;
-import jersey.repackaged.com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/alternativepayment/handler/AbstractAlternativePaymentPendingOrderHandler.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/alternativepayment/handler/AbstractAlternativePaymentPendingOrderHandler.java
@@ -1,7 +1,7 @@
 package isv.sap.payment.service.alternativepayment.handler;
 
 import java.util.Locale;
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 import de.hybris.platform.core.model.order.AbstractOrderModel;
 import de.hybris.platform.core.model.order.OrderModel;

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/alternativepayment/handler/AlternativePaymentAbandonedOrderHandler.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/alternativepayment/handler/AlternativePaymentAbandonedOrderHandler.java
@@ -1,6 +1,6 @@
 package isv.sap.payment.service.alternativepayment.handler;
 
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 import de.hybris.platform.core.model.order.OrderModel;
 

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/executor/request/converter/alternative/CheckStatusRequestConverter.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/executor/request/converter/alternative/CheckStatusRequestConverter.java
@@ -2,7 +2,7 @@ package isv.sap.payment.service.executor.request.converter.alternative;
 
 import de.hybris.platform.core.model.order.AbstractOrderModel;
 import de.hybris.platform.payment.model.PaymentTransactionEntryModel;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import isv.cjl.payment.configuration.transaction.PaymentTransaction;
 import isv.cjl.payment.enums.AlternativePaymentMethod;

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/executor/request/converter/alternative/CreateSessionRequestConverter.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/executor/request/converter/alternative/CreateSessionRequestConverter.java
@@ -30,7 +30,7 @@ import static isv.cjl.payment.enums.AlternativePaymentMethod.KLI;
 import static java.lang.String.format;
 import static java.math.BigDecimal.ZERO;
 import static java.math.BigDecimal.valueOf;
-import static org.apache.commons.lang.StringUtils.abbreviate;
+import static org.apache.commons.lang3.StringUtils.abbreviate;
 
 /**
  * A component that encapsulates conversion logic from {@link PaymentServiceRequest} to

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/executor/request/converter/alternative/RefundRequestConverter.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/executor/request/converter/alternative/RefundRequestConverter.java
@@ -22,7 +22,7 @@ import static isv.cjl.payment.constants.PaymentRequestParamConstants.PURCHASE_TO
 import static isv.cjl.payment.constants.PaymentServiceConstants.AlternativePayment.REFUND;
 import static isv.cjl.payment.enums.AlternativePaymentMethod.APY;
 import static isv.cjl.payment.enums.AlternativePaymentMethod.AYM;
-import static org.apache.commons.lang.StringUtils.EMPTY;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
 
 public class RefundRequestConverter extends AbstractRequestConverter
 {

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/executor/request/converter/alternative/UpdateSessionRequestConverter.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/executor/request/converter/alternative/UpdateSessionRequestConverter.java
@@ -35,7 +35,7 @@ import static isv.cjl.payment.constants.PaymentServiceConstants.AlternativePayme
 import static isv.sap.payment.enums.AlternativePaymentMethod.KLI;
 import static java.lang.String.format;
 import static java.math.BigDecimal.ZERO;
-import static org.apache.commons.lang.StringUtils.abbreviate;
+import static org.apache.commons.lang3.StringUtils.abbreviate;
 
 /**
  * A component that encapsulates conversion logic from {@link PaymentServiceRequest} to

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/executor/request/converter/applepay/AuthorizationRequestConverter.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/executor/request/converter/applepay/AuthorizationRequestConverter.java
@@ -1,7 +1,7 @@
 package isv.sap.payment.service.executor.request.converter.applepay;
 
 import java.util.List;
-import javax.inject.Named;
+import jakarta.inject.Named;
 
 import com.google.inject.Inject;
 

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/executor/request/converter/applepay/SaleRequestConverter.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/executor/request/converter/applepay/SaleRequestConverter.java
@@ -1,6 +1,6 @@
 package isv.sap.payment.service.executor.request.converter.applepay;
 
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 import isv.cjl.payment.service.executor.request.PaymentServiceRequest;
 import isv.cjl.payment.service.executor.request.converter.AbstractRequestConverter;

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/executor/request/converter/creditcard/AuthorizationRequestConverter.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/executor/request/converter/creditcard/AuthorizationRequestConverter.java
@@ -16,7 +16,7 @@ import isv.cjl.payment.service.executor.request.converter.AbstractRequestConvert
 import isv.cjl.payment.service.request.Request;
 import isv.cjl.payment.utils.Assert;
 import isv.cjl.payment.utils.PaymentParamUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import static isv.cjl.payment.constants.PaymentConstants.CommonFields.ORDER;
 import static isv.cjl.payment.constants.PaymentRequestParamConstants.*;

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/executor/request/converter/creditcard/CaptureRequestConverter.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/executor/request/converter/creditcard/CaptureRequestConverter.java
@@ -1,7 +1,7 @@
 package isv.sap.payment.service.executor.request.converter.creditcard;
 
-import javax.inject.Inject;
-import javax.inject.Named;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
 
 import de.hybris.platform.core.model.order.AbstractOrderModel;
 import de.hybris.platform.payment.model.PaymentTransactionEntryModel;

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/executor/request/converter/creditcard/RefundFollowOnRequestConverter.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/executor/request/converter/creditcard/RefundFollowOnRequestConverter.java
@@ -1,8 +1,8 @@
 package isv.sap.payment.service.executor.request.converter.creditcard;
 
 import java.math.BigDecimal;
-import javax.inject.Inject;
-import javax.inject.Named;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
 
 import de.hybris.platform.core.model.order.AbstractOrderModel;
 import de.hybris.platform.payment.model.PaymentTransactionEntryModel;

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/executor/request/converter/creditcard/RefundStandaloneRequestConverter.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/executor/request/converter/creditcard/RefundStandaloneRequestConverter.java
@@ -1,8 +1,8 @@
 package isv.sap.payment.service.executor.request.converter.creditcard;
 
 import java.math.BigDecimal;
-import javax.inject.Inject;
-import javax.inject.Named;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
 
 import com.google.common.base.Optional;
 import de.hybris.platform.core.model.order.AbstractOrderModel;

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/executor/request/converter/googlepay/SaleRequestConverter.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/executor/request/converter/googlepay/SaleRequestConverter.java
@@ -1,6 +1,6 @@
 package isv.sap.payment.service.executor.request.converter.googlepay;
 
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 import isv.cjl.payment.service.executor.request.PaymentServiceRequest;
 import isv.cjl.payment.service.executor.request.converter.AbstractRequestConverter;

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/executor/request/converter/paypal/SaleRequestConverter.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/executor/request/converter/paypal/SaleRequestConverter.java
@@ -29,7 +29,7 @@ import static isv.sap.payment.enums.AlternativePaymentMethod.PPL;
 import static java.lang.String.format;
 import static java.math.BigDecimal.ZERO;
 import static java.math.BigDecimal.valueOf;
-import static org.apache.commons.lang.StringUtils.abbreviate;
+import static org.apache.commons.lang3.StringUtils.abbreviate;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 /**

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/executor/request/converter/verification/DeliveryAddressVerificationRequestConverter.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/executor/request/converter/verification/DeliveryAddressVerificationRequestConverter.java
@@ -16,7 +16,7 @@ import static isv.cjl.payment.constants.PaymentRequestParamConstants.POSTAL_CODE
 import static isv.cjl.payment.constants.PaymentRequestParamConstants.STATE;
 import static isv.cjl.payment.constants.PaymentRequestParamConstants.STREET1;
 import static isv.cjl.payment.constants.PaymentServiceConstants.Verification.DELIVERY_ADDRESS_VERIFICATION;
-import static org.apache.commons.lang.StringUtils.EMPTY;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
 
 /**
  * A component that encapsulates conversion logic from {@link PaymentServiceRequest} to

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/executor/request/populator/processinglevel/AbstractPopulator.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/executor/request/populator/processinglevel/AbstractPopulator.java
@@ -2,7 +2,7 @@ package isv.sap.payment.service.executor.request.populator.processinglevel;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import javax.inject.Named;
+import jakarta.inject.Named;
 
 import com.google.inject.Inject;
 import de.hybris.platform.core.model.order.AbstractOrderEntryModel;

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/transaction/PaymentResultTransactionEntryPopulator.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/transaction/PaymentResultTransactionEntryPopulator.java
@@ -3,7 +3,7 @@ package isv.sap.payment.service.transaction;
 import java.math.BigDecimal;
 import java.util.Map;
 import java.util.stream.Collectors;
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 import com.google.common.collect.Maps;
 import de.hybris.platform.converters.Populator;

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/transaction/PaymentTransactionCreatorContext.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/transaction/PaymentTransactionCreatorContext.java
@@ -1,6 +1,6 @@
 package isv.sap.payment.service.transaction;
 
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 import isv.cjl.payment.service.executor.request.PaymentServiceRequest;
 

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/transaction/PersistentPaymentTransactionCreator.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/transaction/PersistentPaymentTransactionCreator.java
@@ -2,7 +2,7 @@ package isv.sap.payment.service.transaction;
 
 import java.util.Collections;
 import java.util.List;
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 import com.google.common.collect.Lists;
 import de.hybris.platform.core.model.order.AbstractOrderModel;

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/transaction/TransientPaymentTransactionCreator.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/service/transaction/TransientPaymentTransactionCreator.java
@@ -1,6 +1,6 @@
 package isv.sap.payment.service.transaction;
 
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 import de.hybris.platform.enumeration.EnumerationService;
 import de.hybris.platform.payment.enums.PaymentTransactionType;

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/setup/IsvPaymentSystemSetup.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/setup/IsvPaymentSystemSetup.java
@@ -1,6 +1,6 @@
 package isv.sap.payment.setup;
 
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 
 import de.hybris.platform.commerceservices.setup.SetupImpexService;
 import de.hybris.platform.core.initialization.SystemSetup;

--- a/hybris/bin/b2b/isvpayment/src/isv/sap/payment/utils/PaymentTransactionUtils.java
+++ b/hybris/bin/b2b/isvpayment/src/isv/sap/payment/utils/PaymentTransactionUtils.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 
 import de.hybris.platform.payment.model.PaymentTransactionEntryModel;
 import de.hybris.platform.payment.model.PaymentTransactionModel;
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 
 import isv.sap.payment.enums.PaymentType;
 

--- a/hybris/bin/b2b/isvpayment/testsrc/isv/sap/payment/cronjob/AbstractConversionReportPollingJobTest.java
+++ b/hybris/bin/b2b/isvpayment/testsrc/isv/sap/payment/cronjob/AbstractConversionReportPollingJobTest.java
@@ -14,7 +14,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import isv.cjl.payment.model.ConversionReportInfo;
 import isv.sap.payment.cronjob.data.ReportConversionResult;

--- a/hybris/bin/b2b/isvpayment/testsrc/isv/sap/payment/cronjob/DailyConversionReportPollingJobTest.java
+++ b/hybris/bin/b2b/isvpayment/testsrc/isv/sap/payment/cronjob/DailyConversionReportPollingJobTest.java
@@ -11,7 +11,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import isv.cjl.payment.model.ConversionReportInfo;
 import isv.cjl.payment.report.service.ConversionReportService;

--- a/hybris/bin/b2b/isvpayment/testsrc/isv/sap/payment/cronjob/OnDemandConversionReportPollingJobTest.java
+++ b/hybris/bin/b2b/isvpayment/testsrc/isv/sap/payment/cronjob/OnDemandConversionReportPollingJobTest.java
@@ -13,7 +13,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import isv.cjl.payment.model.ConversionReportInfo;
 import isv.cjl.payment.report.service.ConversionReportService;

--- a/hybris/bin/b2b/isvpayment/testsrc/isv/sap/payment/integration/helpers/HybrisIntegrationSpec.groovy
+++ b/hybris/bin/b2b/isvpayment/testsrc/isv/sap/payment/integration/helpers/HybrisIntegrationSpec.groovy
@@ -1,7 +1,7 @@
 package isv.sap.payment.integration.helpers
 
 import java.lang.reflect.Field
-import javax.annotation.Resource
+import jakarta.annotation.Resource
 
 import de.hybris.platform.core.Registry
 import de.hybris.platform.servicelayer.ServicelayerBaseTest

--- a/hybris/bin/b2b/isvpayment/testsrc/isv/sap/payment/integration/helpers/IsvIntegrationSpec.groovy
+++ b/hybris/bin/b2b/isvpayment/testsrc/isv/sap/payment/integration/helpers/IsvIntegrationSpec.groovy
@@ -1,6 +1,6 @@
 package isv.sap.payment.integration.helpers
 
-import javax.annotation.Resource
+import jakarta.annotation.Resource
 
 import de.hybris.bootstrap.config.ConfigUtil
 import de.hybris.platform.core.Registry

--- a/hybris/bin/b2b/isvpayment/testsrc/isv/sap/payment/integration/reporting/DailyConversionReportServiceIntegrationSpec.groovy
+++ b/hybris/bin/b2b/isvpayment/testsrc/isv/sap/payment/integration/reporting/DailyConversionReportServiceIntegrationSpec.groovy
@@ -1,6 +1,6 @@
 package isv.sap.payment.integration.reporting
 
-import javax.annotation.Resource
+import jakarta.annotation.Resource
 
 import de.hybris.bootstrap.annotations.ManualTest
 import org.junit.Ignore

--- a/hybris/bin/b2b/isvpayment/testsrc/isv/sap/payment/option/service/DefaultPaymentOptionServiceSpec.groovy
+++ b/hybris/bin/b2b/isvpayment/testsrc/isv/sap/payment/option/service/DefaultPaymentOptionServiceSpec.groovy
@@ -6,12 +6,11 @@ import de.hybris.platform.servicelayer.search.FlexibleSearchService
 import de.hybris.platform.servicelayer.search.impl.SearchResultImpl
 import org.junit.Test
 import spock.lang.Specification
-
+import java.util.Collections;
 import isv.sap.payment.model.IsvAlternativePaymentOptionModel
 
 import static isv.sap.payment.option.service.DefaultPaymentOptionService.OPTIONS_QUERY
 import static java.util.Arrays.asList
-import static org.apache.commons.collections.ListUtils.EMPTY_LIST
 
 @UnitTest
 class DefaultPaymentOptionServiceSpec extends Specification
@@ -55,7 +54,7 @@ class DefaultPaymentOptionServiceSpec extends Specification
         def actual = service.paymentOptions
 
         then:
-        actual == EMPTY_LIST
+        actual == Collections.emptyList()
     }
 
     @Test

--- a/hybris/bin/b2b/isvpayment/testsrc/isv/sap/payment/service/alternativepayment/handler/AbstractAlternativePaymentPendingOrderHandlerSpec.groovy
+++ b/hybris/bin/b2b/isvpayment/testsrc/isv/sap/payment/service/alternativepayment/handler/AbstractAlternativePaymentPendingOrderHandlerSpec.groovy
@@ -8,7 +8,7 @@ import de.hybris.bootstrap.annotations.UnitTest
 import de.hybris.platform.core.model.order.AbstractOrderModel
 import de.hybris.platform.core.model.order.OrderModel
 import de.hybris.platform.payment.enums.PaymentTransactionType
-import jersey.repackaged.com.google.common.collect.ImmutableMap
+import com.google.common.collect.ImmutableMap
 import org.junit.Test
 import spock.lang.Specification
 

--- a/hybris/bin/b2b/isvpayment/testsrc/isv/sap/payment/service/executor/request/converter/alternative/RefundRequestConverterSpec.groovy
+++ b/hybris/bin/b2b/isvpayment/testsrc/isv/sap/payment/service/executor/request/converter/alternative/RefundRequestConverterSpec.groovy
@@ -18,7 +18,7 @@ import static isv.cjl.payment.enums.AlternativePaymentMethod.KLI
 import static isv.cjl.payment.enums.AlternativePaymentMethod.MCH
 import static isv.cjl.payment.enums.AlternativePaymentMethod.SOF
 import static java.math.BigDecimal.TEN
-import static org.apache.commons.lang.StringUtils.EMPTY
+import static org.apache.commons.lang3.StringUtils.EMPTY
 
 class RefundRequestConverterSpec extends Specification
 {

--- a/hybris/bin/b2b/isvpayment/testsrc/isv/sap/payment/service/executor/request/converter/verification/ExportComplianceRequestConverterSpec.groovy
+++ b/hybris/bin/b2b/isvpayment/testsrc/isv/sap/payment/service/executor/request/converter/verification/ExportComplianceRequestConverterSpec.groovy
@@ -18,7 +18,7 @@ import static isv.cjl.payment.enums.ExportComplianceAddressOperator.IGNORE
 import static isv.cjl.payment.enums.ExportComplianceFieldWeight.HIGH
 import static isv.cjl.payment.enums.ExportComplianceFieldWeight.LOW
 import static isv.cjl.payment.enums.ExportComplianceFieldWeight.MEDIUM
-import static org.apache.commons.lang.StringUtils.EMPTY
+import static org.apache.commons.lang3.StringUtils.EMPTY
 
 @UnitTest
 class ExportComplianceRequestConverterSpec extends Specification


### PR DESCRIPTION
Cybersource (v25.2.0) compatibility fixes for Hybris JDK21.
- Majorly jar updates are done (Only external JARS are added)
- Import changes from javax to jakarta

<img width="833" height="453" alt="image" src="https://github.com/user-attachments/assets/2c36da54-d3b5-4775-837b-f5f49dd580a6" />
